### PR TITLE
Endpoint

### DIFF
--- a/CodeCraftApi.Test/Exercises/CreateExerciseTest.cs
+++ b/CodeCraftApi.Test/Exercises/CreateExerciseTest.cs
@@ -1,39 +1,51 @@
 ﻿using CodeCraftApi.Database;
 using CodeCraftApi.Domain.Entities;
 using CodeCraftApi.Features.Exercises.CreateExercise;
-using FakeItEasy;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Shouldly;
 
 namespace CodeCraftApi.Test.Exercises;
-public class CreateExerciseTest()
+
+
+public class CreateExerciseEndpointTests
 {
 	[Fact]
-	public async Task CreateExercise()
+	public async Task Create_Success()
 	{
-		Exercise exercise = new Exercise();
+		var options = new DbContextOptionsBuilder<AppDbContext>()
+			.UseInMemoryDatabase(databaseName: "TestDatabase_" + Guid.NewGuid())
+			.Options;
+    
+		var context = new AppDbContext(options);
+    
+		var ep = Factory.Create<CreateExerciseEndpoint>(
+			ctx => {
+				ctx.AddTestServices(s => {
+					
+				});
+			},
+			context);
 
-		var fakeContext = A.Fake<AppDbContext>();
-		var fakeDbSet = A.Fake<DbSet<Exercise>>();
-		A.CallTo(() => fakeContext.Exercises).Returns(fakeDbSet);
-		A.CallTo(() => fakeDbSet.Add(A<Exercise>.Ignored));
-
-
-		var fakeConfig = A.Fake<IConfiguration>();
-		A.CallTo(() => fakeConfig["tokenKey"]).Returns("Fake_Token_Signing_Secret");
-
-		var endPoint = Factory.Create<CreateExerciseEndpoint>(fakeConfig);
-
-		var req = new CreateExerciseRequest
+		var req = new CreateExerciseRequest()
 		{
-
+			Title = "Title",
+			Summary = "Test summary",
+			ExerciseDifficulty = ExerciseDifficulty.Easy,
+			SubExercises = []
 		};
 
-		await endPoint.HandleAsync(req, default);
-		var rsp = endPoint.Response;
+		try {
+			await ep.HandleAsync(req, CancellationToken.None);
+		}
+		catch (InvalidOperationException ex) when (ex.Message.Contains("LinkGenerator")) {
+		}
 
-		rsp.ShouldNotBeNull();
+		var savedExercise = await context.Exercises.FirstOrDefaultAsync(e => e.Title == "Title");
+		savedExercise.ShouldNotBeNull();
+		savedExercise.Title.ShouldBe("Title");
+		savedExercise.Summary.ShouldBe("Test summary");
+		savedExercise.ExerciseDifficulty.ShouldBe(ExerciseDifficulty.Easy);
 	}
+
 }

--- a/CodeCraftApi/Features/Exercises/CreateExercise/Mapper.cs
+++ b/CodeCraftApi/Features/Exercises/CreateExercise/Mapper.cs
@@ -42,18 +42,10 @@ internal sealed class Mapper : Mapper<CreateExerciseRequest, CreateExerciseRespo
 	public static List<ExerciseItem> ItemToEntity(List<CreateExerciseItem> r)
 	{
 		List<ExerciseItem> items = [];
-
-		foreach (var item in r)
+		items.AddRange(r.Select(item => new ExerciseItem()
 		{
-			ExerciseItem exerciseItem = new()
-			{
-				Id = Guid.NewGuid(),
-				Title = item.Title,
-				Number = item.Number,
-				Steps = StepToEntity(item.Steps),
-			};
-			items.Add(exerciseItem);
-		}
+			Id = Guid.NewGuid(), Title = item.Title, Number = item.Number, Steps = StepToEntity(item.Steps),
+		}));
 
 		return items;
 	}
@@ -61,18 +53,10 @@ internal sealed class Mapper : Mapper<CreateExerciseRequest, CreateExerciseRespo
 	public static List<ExerciseItemResponse> EntityToItemResponse(List<ExerciseItem> exerciseItems)
 	{
 		List<ExerciseItemResponse> items = [];
-
-		foreach (var item in exerciseItems)
+		items.AddRange(exerciseItems.Select(item => new ExerciseItemResponse()
 		{
-			ExerciseItemResponse response = new()
-			{
-				Id = Guid.NewGuid(),
-				Title = item.Title,
-				Number = item.Number,
-				Steps = EntityToStepResponse(item.Steps),
-			};
-			items.Add(response);
-		}
+			Id = Guid.NewGuid(), Title = item.Title, Number = item.Number, Steps = EntityToStepResponse(item.Steps),
+		}));
 
 		return items;
 	}
@@ -80,21 +64,16 @@ internal sealed class Mapper : Mapper<CreateExerciseRequest, CreateExerciseRespo
 	public static List<ExerciseStep> StepToEntity(List<CreateExerciseStep> r)
 	{
 		List<ExerciseStep> steps = [];
-
-		foreach (var item in r)
+		steps.AddRange(r.Select(item => new ExerciseStep()
 		{
-			ExerciseStep step = new()
-			{
-				Id = Guid.NewGuid(),
-				Title = item.Title,
-				Description = item.Description,
-				DescriptionShort = item.DescriptionShort,
-				Contraints = item.Contraints,
-				Hints = item.Hints,
-				Tests = []
-			};
-			steps.Add(step);
-		}
+			Id = Guid.NewGuid(),
+			Title = item.Title,
+			Description = item.Description,
+			DescriptionShort = item.DescriptionShort,
+			Contraints = item.Contraints,
+			Hints = item.Hints,
+			Tests = []
+		}));
 
 		return steps;
 	}
@@ -102,21 +81,16 @@ internal sealed class Mapper : Mapper<CreateExerciseRequest, CreateExerciseRespo
 	public static List<ExerciseStepResponse> EntityToStepResponse(List<ExerciseStep> exerciseSteps)
 	{
 		List<ExerciseStepResponse> steps = [];
-
-		foreach (var item in exerciseSteps)
+		steps.AddRange(exerciseSteps.Select(item => new ExerciseStepResponse()
 		{
-			ExerciseStepResponse step = new()
-			{
-				Id = Guid.NewGuid(),
-				Title = item.Title,
-				Description = item.Description,
-				DescriptionShort = item.DescriptionShort,
-				Contraints = item.Contraints,
-				Hints = item.Hints,
-				Tests = item.Tests
-			};
-			steps.Add(step);
-		}
+			Id = Guid.NewGuid(),
+			Title = item.Title,
+			Description = item.Description,
+			DescriptionShort = item.DescriptionShort,
+			Contraints = item.Contraints,
+			Hints = item.Hints,
+			Tests = item.Tests
+		}));
 
 		return steps;
 	}

--- a/CodeCraftApi/Features/Exercises/GetExerciseItem/Data.cs
+++ b/CodeCraftApi/Features/Exercises/GetExerciseItem/Data.cs
@@ -1,0 +1,15 @@
+namespace CodeCraftApi.Features.Exercises.GetExerciseItem;
+
+using Database;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+internal sealed class Data
+{
+    public static async Task<ExerciseItem?> GetExerciseItemsAsync(AppDbContext db, Guid id)
+    {
+        return await db.ExerciseItem
+            .FirstOrDefaultAsync(x => x.Id == id);
+    } 
+    
+}

--- a/CodeCraftApi/Features/Exercises/GetExerciseItem/Endpoint.cs
+++ b/CodeCraftApi/Features/Exercises/GetExerciseItem/Endpoint.cs
@@ -1,0 +1,29 @@
+namespace CodeCraftApi.Features.Exercises.GetExerciseItem;
+
+using Database;
+
+internal sealed class GetExerciseItemEndpoint(AppDbContext context) 
+    : Endpoint<GetExerciseItemRequest,GetExerciseItemResponse, Mapper>
+{
+    public override void Configure()
+    {
+        Get("/Item/{ExerciseItemId}");
+        Group<ExerciseGroup>();
+        Description(x =>  x.WithName("Get Exercise Item"));
+        Summary(new Summary());
+    }
+
+    public override async Task HandleAsync(GetExerciseItemRequest req, CancellationToken ct)
+    {
+        var exerciseItem = await Data.GetExerciseItemsAsync(context, req.ExerciseItemId);
+
+        if (exerciseItem == null)
+        {
+            await SendNotFoundAsync(ct);
+        }
+        else
+        {
+            await SendAsync(Map.FromEntity(exerciseItem), cancellation: ct);
+        }
+    }
+}

--- a/CodeCraftApi/Features/Exercises/GetExerciseItem/Mapper.cs
+++ b/CodeCraftApi/Features/Exercises/GetExerciseItem/Mapper.cs
@@ -1,0 +1,37 @@
+namespace CodeCraftApi.Features.Exercises.GetExerciseItem;
+
+using Domain.Entities;
+using Shared;
+
+internal sealed class Mapper
+    : Mapper<GetExerciseItemRequest, GetExerciseItemResponse, ExerciseItem>
+{
+    public override GetExerciseItemResponse FromEntity(ExerciseItem eI)
+    {
+        GetExerciseItemResponse r = new()
+        {
+            Id = eI.Id,
+            Title = eI.Title,
+            Number = eI.Number,
+            Steps = EntityToStepResponse(eI.Steps)
+
+        };
+        return r;
+    }
+
+    private static List<ExerciseStepResponse>? EntityToStepResponse(List<ExerciseStep> exerciseSteps)
+    {
+        return exerciseSteps?
+            .Select(item => new ExerciseStepResponse
+            {
+                Id = Guid.NewGuid(),
+                Title = item.Title,
+                Description = item.Description,
+                DescriptionShort = item.DescriptionShort,
+                Contraints = item.Contraints,
+                Hints = item.Hints,
+                Tests = item.Tests
+            })
+            .ToList() ?? [];
+    } 
+}

--- a/CodeCraftApi/Features/Exercises/GetExerciseItem/Models.cs
+++ b/CodeCraftApi/Features/Exercises/GetExerciseItem/Models.cs
@@ -1,0 +1,26 @@
+namespace CodeCraftApi.Features.Exercises.GetExerciseItem;
+
+using Domain.Entities;
+using FluentValidation;
+using Shared;
+
+internal sealed class GetExerciseItemRequest
+{
+    public Guid ExerciseItemId { get; set; }
+
+    internal sealed class Validator : Validator<GetExerciseItemRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.ExerciseItemId).NotEmpty();
+        }
+    }
+}
+
+internal sealed class GetExerciseItemResponse
+{
+    public Guid Id { get; set; }
+    public int Number { get; set; }
+    public string? Title { get; set; }
+    public List<ExerciseStepResponse>? Steps { get; set; }
+}

--- a/CodeCraftApi/Features/Exercises/GetExerciseItem/Summary.cs
+++ b/CodeCraftApi/Features/Exercises/GetExerciseItem/Summary.cs
@@ -1,0 +1,34 @@
+namespace CodeCraftApi.Features.Exercises.GetExerciseItem;
+
+using Shared;
+
+internal sealed class Summary : EndpointSummary
+{
+    public Summary()
+    {
+        Summary = "Gets an Exercise item.";
+        Description = "Gets an Exercise item.";
+        
+        ResponseExamples[201] = new GetExerciseItemResponse
+        {
+            Id = Guid.NewGuid(),
+            Title = "Step 1",
+            Number = 1,
+            Steps =
+            [
+                new ExerciseStepResponse
+                {
+                    Id = Guid.NewGuid(),
+                    Contraints = "none",
+                    Description = "Step 1",
+                    DescriptionShort = "Step 1 short",
+                    Hints = "none gl hf",
+                    Tests = [],
+                    Title = "First step",
+                }
+            ]
+        };
+        Responses[403] = "Forbidden - insufficient permission";
+    }
+    
+}


### PR DESCRIPTION
This pull request includes several changes to the test and implementation of the exercise creation and retrieval features in the `CodeCraftApi` project. The most important changes involve refactoring the `CreateExerciseTest` class, simplifying the `Mapper` methods, and adding a new endpoint for retrieving exercise items.

### Refactoring and Testing Improvements:

* [`CodeCraftApi.Test/Exercises/CreateExerciseTest.cs`](diffhunk://#diff-cd353d984b237df0ef4d95b483b45b787cf870bc6c70758fd19bc0517fe8f3e4L4-R50): Refactored the `CreateExerciseTest` class to use an in-memory database for testing, removed the use of `FakeItEasy`, and updated the test method to validate the saved exercise properties.

### Simplification of Mapper Methods:

* [`CodeCraftApi/Features/Exercises/CreateExercise/Mapper.cs`](diffhunk://#diff-4c339a11ffd4e58efc5e2b64044e7ec0280d3e24d17abf6fa3e512780c76e8b4L45-R67): Simplified the `ItemToEntity`, `EntityToItemResponse`, `StepToEntity`, and `EntityToStepResponse` methods by using LINQ's `Select` method and `AddRange` instead of manual iteration and addition. [[1]](diffhunk://#diff-4c339a11ffd4e58efc5e2b64044e7ec0280d3e24d17abf6fa3e512780c76e8b4L45-R67) [[2]](diffhunk://#diff-4c339a11ffd4e58efc5e2b64044e7ec0280d3e24d17abf6fa3e512780c76e8b4L95-R84) [[3]](diffhunk://#diff-4c339a11ffd4e58efc5e2b64044e7ec0280d3e24d17abf6fa3e512780c76e8b4L117-R93)

### New Endpoint for Retrieving Exercise Items:

* [`CodeCraftApi/Features/Exercises/GetExerciseItem/Data.cs`](diffhunk://#diff-55ae208453c5c78d1ea80f383ad6ca0b77f55fe8bfe27fab39e6ea40c7083288R1-R15): Added a new data access class with a method to retrieve exercise items by ID.
* [`CodeCraftApi/Features/Exercises/GetExerciseItem/Endpoint.cs`](diffhunk://#diff-6c873d975733bd62a5af49bdeed48b1da1ae85623970161aa13f7da1f2715fc5R1-R29): Implemented a new endpoint class for handling requests to retrieve exercise items, including configuration and request handling logic.
* [`CodeCraftApi/Features/Exercises/GetExerciseItem/Mapper.cs`](diffhunk://#diff-4d81059dc78d812c6da1105595dffff3a54f9eb5c2f3aad61525169fc7caf9b2R1-R37): Added a new mapper class for converting `ExerciseItem` entities to `GetExerciseItemResponse` objects.
* [`CodeCraftApi/Features/Exercises/GetExerciseItem/Models.cs`](diffhunk://#diff-4e9911c4f40fcf7223faca50014f149a8d437a7464eb3afb0f9de34507b4f350R1-R26): Defined request and response models for the new endpoint, including validation rules.
* [`CodeCraftApi/Features/Exercises/GetExerciseItem/Summary.cs`](diffhunk://#diff-64657b599d09687e615d8501e3d423a85494dbece24b41bba4a7637bcc15a3f9R1-R34): Added a summary class to provide endpoint documentation and response examples.