### PR TITLE
Add role-based access control for teacher actions

### DIFF
--- a/CodeCraftUI/app/features/exercises/components/exercise-card.tsx
+++ b/CodeCraftUI/app/features/exercises/components/exercise-card.tsx
@@ -9,6 +9,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "~/components/ui/card";
+import useAuth from "~/hooks/useAuth";
 
 export default function ExerciseCard({
 	setSaved,
@@ -19,6 +20,8 @@ export default function ExerciseCard({
 	exercise: any;
 	setExercises: React.Dispatch<React.SetStateAction<any[]>>;
 }) {
+	const { user } = useAuth();
+
 	return (
 		<Card
 			key={exercise.id}
@@ -36,26 +39,30 @@ export default function ExerciseCard({
 			</CardHeader>
 			<CardFooter className="flex items-center justify-between">
 				<div className="flex items-center gap-2">
-					<Label
-						className={`${
-							exercise.isVisible ? "text-foreground/100" : "text-foreground/50"
-						} hover:cursor-pointer`}
-					>
-						<Switch
-							onCheckedChange={() => {
-								setSaved(false);
-								setExercises((prev) =>
-									prev.map((ex) =>
-										ex.id === exercise.id
-											? { ...ex, isVisible: !ex.isVisible }
-											: ex
-									)
-								);
-							}}
-							defaultChecked={exercise.isVisible}
-						/>
-						{exercise.isVisible ? "Visible" : "Hidden"}
-					</Label>
+					{user?.user_metadata.role === "teacher" && (
+						<Label
+							className={`${
+								exercise.isVisible
+									? "text-foreground/100"
+									: "text-foreground/50"
+							} hover:cursor-pointer`}
+						>
+							<Switch
+								onCheckedChange={() => {
+									setSaved(false);
+									setExercises((prev) =>
+										prev.map((ex) =>
+											ex.id === exercise.id
+												? { ...ex, isVisible: !ex.isVisible }
+												: ex
+										)
+									);
+								}}
+								defaultChecked={exercise.isVisible}
+							/>
+							{exercise.isVisible ? "Visible" : "Hidden"}
+						</Label>
+					)}
 				</div>
 				<NavLink to={"/exercises/details/" + exercise.id}>
 					<Button>Details</Button>

--- a/CodeCraftUI/app/features/exercises/components/exercise-dashboard.tsx
+++ b/CodeCraftUI/app/features/exercises/components/exercise-dashboard.tsx
@@ -1,23 +1,30 @@
 import { Button } from "~/components/ui/button";
 import { NavLink } from "react-router";
+import useAuth from "~/hooks/useAuth";
 
 export default function ExerciseDashboard() {
+	const { user } = useAuth();
+
 	return (
 		<div className="flex w-full h-full items-center justify-center space-x-10">
-			<div>
-				<NavLink to="/exercises/create">
-					<Button className="flex flex-col items-center h-15">
-						Create Exercise
-					</Button>
-				</NavLink>
-			</div>
-			<div>
-				<NavLink to="/exercises" className={"cursor-not-allowed"}>
-					<Button className="flex flex-col items-center h-15" disabled>
-						Update Exercise
-					</Button>
-				</NavLink>
-			</div>
+			{user?.user_metadata.role === "teacher" && (
+				<>
+					<div>
+						<NavLink to="/exercises/create">
+							<Button className="flex flex-col items-center h-15">
+								Create Exercise
+							</Button>
+						</NavLink>
+					</div>
+					<div>
+						<NavLink to="/exercises" className={"cursor-not-allowed"}>
+							<Button className="flex flex-col items-center h-15" disabled>
+								Update Exercise
+							</Button>
+						</NavLink>
+					</div>
+				</>
+			)}
 			<div>
 				<NavLink to="/exercises/view">
 					<Button className="flex flex-col items-center h-15">

--- a/CodeCraftUI/app/features/exercises/components/exercise-overview.tsx
+++ b/CodeCraftUI/app/features/exercises/components/exercise-overview.tsx
@@ -13,12 +13,14 @@ import { Button } from "~/components/ui/button";
 import { FaCheck } from "react-icons/fa6";
 import { AiOutlineLoading } from "react-icons/ai";
 import ExerciseCard from "./exercise-card";
+import useAuth from "~/hooks/useAuth";
 
 export default function ExerciseOverview() {
 	const { getExercises, toggleVisibility, loading } = useExercise();
 	const [exercises, setExercises] = useState<any[]>([]);
 	const [originalExercises, setOriginalExercises] = useState<any[]>([]);
 	const [saved, setSaved] = useState(false);
+	const { user } = useAuth();
 
 	function stateChanged() {
 		if (exercises.length !== originalExercises.length) return false;
@@ -61,24 +63,28 @@ export default function ExerciseOverview() {
 							</BreadcrumbItem>
 						</BreadcrumbList>
 					</Breadcrumb>
-					<Button
-						className="mr-10 active:bg-primary/40"
-						onClick={() => {
-							const changes = exercises.map((exercise) => ({
-								exerciseId: exercise.id,
-								isVisible: exercise.isVisible,
-							}));
-							toggleVisibility(changes).then(() => {
-								setSaved(true);
-								setOriginalExercises(JSON.parse(JSON.stringify(exercises)));
-							});
-						}}
-						disabled={stateChanged()}
-					>
-						{loading ? "Saving..." : saved ? "Changes saved" : "Save Changes"}
-						{saved && <FaCheck />}
-						{!saved && loading && <AiOutlineLoading className="animate-spin" />}
-					</Button>
+					{user?.user_metadata.role === "teacher" && (
+						<Button
+							className="mr-10 active:bg-primary/40"
+							onClick={() => {
+								const changes = exercises.map((exercise) => ({
+									exerciseId: exercise.id,
+									isVisible: exercise.isVisible,
+								}));
+								toggleVisibility(changes).then(() => {
+									setSaved(true);
+									setOriginalExercises(JSON.parse(JSON.stringify(exercises)));
+								});
+							}}
+							disabled={stateChanged()}
+						>
+							{loading ? "Saving..." : saved ? "Changes saved" : "Save Changes"}
+							{saved && <FaCheck />}
+							{!saved && loading && (
+								<AiOutlineLoading className="animate-spin" />
+							)}
+						</Button>
+					)}
 				</div>
 			</div>
 			<div className="w-full p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-4">


### PR DESCRIPTION
Introduced role-based visibility for UI elements and actions using the `useAuth` hook to check the user's role. Restricted features like toggling exercise visibility, creating exercises, and saving changes to users with the `teacher` role. Removed unconditional UI elements previously accessible to all users. Preserved functionality for non-teacher users to view exercises and interact with unrestricted features. Enhances security and aligns functionality with role-specific requirements.